### PR TITLE
Fixing Android pushnotifications duplicating

### DIFF
--- a/sample-core/src/main/assets/qb_config.json
+++ b/sample-core/src/main/assets/qb_config.json
@@ -1,10 +1,10 @@
 {
-  "app_id": "72448",
-  "auth_key": "f4HYBYdeqTZ7KNb",
-  "auth_secret": "ZC7dK39bOjVc-Z8",
-  "account_key": "C4_z7nuaANnBYmsG_k98",
+  "app_id": "73803",
+  "auth_key": "qp4zDcV8mk29Qp9",
+  "auth_secret": "Hm2KgDE6eeMZHu5",
+  "account_key": "uK_8uinNyz8-npTNB6tx",
   "api_domain": "https://api.quickblox.com",
   "chat_domain": "chat.quickblox.com",
-  "gcm_sender_id": "761750217637"
+  "gcm_sender_id": "785642683386"
 }
 

--- a/sample-core/src/main/java/com/quickblox/sample/core/gcm/CoreGcmPushListenerService.java
+++ b/sample-core/src/main/java/com/quickblox/sample/core/gcm/CoreGcmPushListenerService.java
@@ -11,7 +11,6 @@ public abstract class CoreGcmPushListenerService extends QBGcmPushListenerServic
 
     @Override
     public void sendPushMessage(Bundle data, String from, String message) {
-        super.sendPushMessage(data, from, message);
         Log.v(TAG, "From: " + from);
         Log.v(TAG, "Message: " + message);
 

--- a/sample-core/src/main/java/com/quickblox/sample/core/gcm/CoreGcmPushListenerService.java
+++ b/sample-core/src/main/java/com/quickblox/sample/core/gcm/CoreGcmPushListenerService.java
@@ -11,6 +11,7 @@ public abstract class CoreGcmPushListenerService extends QBGcmPushListenerServic
 
     @Override
     public void sendPushMessage(Bundle data, String from, String message) {
+        super.sendPushMessage(data, from, message);
         Log.v(TAG, "From: " + from);
         Log.v(TAG, "Message: " + message);
 

--- a/sample-pushnotifications/src/main/AndroidManifest.xml
+++ b/sample-pushnotifications/src/main/AndroidManifest.xml
@@ -66,7 +66,7 @@
             </intent-filter>
         </service>
 
-        <service android:name="com.quickblox.messages.services.fcm.QBFcmPushListenerService">
+        <service android:name=".fcm.FCMPushListenerService">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>

--- a/sample-pushnotifications/src/main/assets/qb_config.json
+++ b/sample-pushnotifications/src/main/assets/qb_config.json
@@ -1,10 +1,10 @@
 {
-  "app_id": "72448",
-  "auth_key": "f4HYBYdeqTZ7KNb",
-  "auth_secret": "ZC7dK39bOjVc-Z8",
-  "account_key": "C4_z7nuaANnBYmsG_k98",
+  "app_id": "73803",
+  "auth_key": "qp4zDcV8mk29Qp9",
+  "auth_secret": "Hm2KgDE6eeMZHu5",
+  "account_key": "uK_8uinNyz8-npTNB6tx",
   "api_domain": "https://api.quickblox.com",
   "chat_domain": "chat.quickblox.com",
-  "gcm_sender_id": "763802285074"
+  "gcm_sender_id": "785642683386"
 }
 

--- a/sample-pushnotifications/src/main/assets/sample_config.json
+++ b/sample-pushnotifications/src/main/assets/sample_config.json
@@ -1,4 +1,4 @@
 {
-  "user_login": "test_user_id2",
-  "user_password": "test_user_id2"
+  "user_login": "testuser01",
+  "user_password": "testuser"
 }

--- a/sample-pushnotifications/src/main/java/com/quickblox/sample/pushnotifications/App.java
+++ b/sample-pushnotifications/src/main/java/com/quickblox/sample/pushnotifications/App.java
@@ -6,6 +6,7 @@ import com.google.android.gms.common.GoogleApiAvailability;
 import com.quickblox.messages.services.QBPushManager;
 import com.quickblox.sample.core.CoreApp;
 import com.quickblox.sample.core.utils.ActivityLifecycle;
+import com.quickblox.sample.core.utils.SharedPrefsHelper;
 import com.quickblox.sample.core.utils.Toaster;
 
 public class App extends CoreApp {
@@ -13,13 +14,37 @@ public class App extends CoreApp {
     private static final String TAG = App.class.getSimpleName();
     private static App instance;
 
+    private static final String FCM_CHANNEL_KEY = "fcm_channel";
+    private static final String GCM_CHANNEL_KEY = "gcm_channel";
+
     @Override
     public void onCreate() {
         super.onCreate();
         instance = this;
         ActivityLifecycle.init(this);
-
+        setEnabledPushChannels();
         initPushManager();
+    }
+
+    private void setEnabledPushChannels() {
+        SharedPrefsHelper.getInstance().save(GCM_CHANNEL_KEY, true);
+        SharedPrefsHelper.getInstance().save(FCM_CHANNEL_KEY, true);
+    }
+
+    public Boolean isGcmEnabled() {
+        return SharedPrefsHelper.getInstance().get(GCM_CHANNEL_KEY, true);
+    }
+
+    public Boolean isFcmEnabled() {
+        return SharedPrefsHelper.getInstance().get(FCM_CHANNEL_KEY, true);
+    }
+
+    public void setEnableFcmChannel(Boolean enable) {
+        SharedPrefsHelper.getInstance().save(FCM_CHANNEL_KEY, enable);
+    }
+
+    public void setEnableGcmChannel(Boolean enable) {
+        SharedPrefsHelper.getInstance().save(GCM_CHANNEL_KEY, enable);
     }
 
     private void initPushManager() {

--- a/sample-pushnotifications/src/main/java/com/quickblox/sample/pushnotifications/fcm/FCMPushListenerService.java
+++ b/sample-pushnotifications/src/main/java/com/quickblox/sample/pushnotifications/fcm/FCMPushListenerService.java
@@ -1,0 +1,26 @@
+package com.quickblox.sample.pushnotifications.fcm;
+
+import com.google.firebase.messaging.RemoteMessage;
+import com.quickblox.messages.services.fcm.QBFcmPushListenerService;
+import com.quickblox.sample.pushnotifications.App;
+
+import java.util.Map;
+
+/**
+ * Created by egor on 10/9/18.
+ */
+
+public class FCMPushListenerService extends QBFcmPushListenerService {
+
+    @Override
+    public void onMessageReceived(RemoteMessage remoteMessage) {
+        if (App.getInstance().isFcmEnabled()) {
+            super.onMessageReceived(remoteMessage);
+        }
+    }
+
+    @Override
+    protected void sendPushMessage(Map data, String from, String message) {
+        super.sendPushMessage(data, from, message);
+    }
+}

--- a/sample-pushnotifications/src/main/java/com/quickblox/sample/pushnotifications/gcm/GcmPushListenerService.java
+++ b/sample-pushnotifications/src/main/java/com/quickblox/sample/pushnotifications/gcm/GcmPushListenerService.java
@@ -1,15 +1,35 @@
 package com.quickblox.sample.pushnotifications.gcm;
 
-import com.quickblox.sample.core.gcm.CoreGcmPushListenerService;
+import android.os.Bundle;
+import android.util.Log;
+
+import com.quickblox.messages.services.gcm.QBGcmPushListenerService;
+import com.quickblox.sample.core.utils.ActivityLifecycle;
 import com.quickblox.sample.core.utils.NotificationUtils;
 import com.quickblox.sample.core.utils.ResourceUtils;
+import com.quickblox.sample.pushnotifications.App;
 import com.quickblox.sample.pushnotifications.R;
 import com.quickblox.sample.pushnotifications.activities.SplashActivity;
 
-public class GcmPushListenerService extends CoreGcmPushListenerService {
+public class GcmPushListenerService extends QBGcmPushListenerService {
+    private static final String TAG = GcmPushListenerService.class.getSimpleName();
+
     private static final int NOTIFICATION_ID = 1;
 
     @Override
+    public void sendPushMessage(Bundle data, String from, String message) {
+        if (App.getInstance().isGcmEnabled()) {
+            super.sendPushMessage(data, from, message);
+
+            Log.v(TAG, "From: " + from);
+            Log.v(TAG, "Message: " + message);
+
+            if (ActivityLifecycle.getInstance().isBackground()) {
+                showNotification(message);
+            }
+        }
+    }
+
     protected void showNotification(String message) {
         NotificationUtils.showNotification(this, SplashActivity.class,
                 ResourceUtils.getString(R.string.notification_title), message,

--- a/sample-pushnotifications/src/main/res/layout/activity_messages.xml
+++ b/sample-pushnotifications/src/main/res/layout/activity_messages.xml
@@ -31,13 +31,33 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="3"
+        android:layout_weight="4"
         android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <CheckBox
+                android:id="@+id/gcm"
+                android:text="@string/gcm"
+                android:layout_weight="1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+            <CheckBox
+                android:id="@+id/fcm"
+                android:text="@string/fcm"
+                android:layout_weight="1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
 
         <com.devspark.robototextview.widget.RobotoTextView
             android:id="@+id/text_messages_header"
             style="@style/HeaderStyle"
-            android:layout_marginTop="@dimen/margin_large"
+            android:layout_marginTop="@dimen/margin_small"
             android:text="@string/received_messages" />
 
         <TextView
@@ -50,5 +70,4 @@
             android:id="@+id/list_messages"
             style="@style/MatchParent" />
     </LinearLayout>
-
 </LinearLayout>

--- a/sample-pushnotifications/src/main/res/values/dimens.xml
+++ b/sample-pushnotifications/src/main/res/values/dimens.xml
@@ -5,6 +5,7 @@
 
     <dimen name="line_width">1dp</dimen>
 
+    <dimen name="margin_small">12dp</dimen>
     <dimen name="margin_medium">46dp</dimen>
     <dimen name="margin_large">80dp</dimen>
 

--- a/sample-pushnotifications/src/main/res/values/strings.xml
+++ b/sample-pushnotifications/src/main/res/values/strings.xml
@@ -17,8 +17,10 @@
 
     <string name="enable_notification">Enable Notification</string>
     <string name="disable_notification">Disable Notification</string>
+    <string name="gcm">GCM</string>
+    <string name="fcm">FCM</string>
     <string name="subtitle_enabled">Notification enabled</string>
     <string name="subtitle_disabled">Notification disabled</string>
-    <string name="sender_id">763802285074</string>
+    <string name="sender_id">785642683386</string>
 
 </resources>


### PR DESCRIPTION
Fixing Android pushnotifications duplicating

*Make sure that you wrote the tests for your proposed changes and the existing test was success.*

**Made/Proposed changes:**
*(Don’t use general words, describe changes in details)*
- removed the super class method sendPushMessage calling from CoreGcmPushListenerService, to fix dublicating of push notifications in pushNotifications Sample

**How should this be manually tested?**
Install application to any Android device and send one Push Message from it. You will receive one notification. 

**Does the documentation need an update?**
Documentation changing is not needed.