### PR TITLE
fixed issue when received attachments do not notifyed in Dialogs Screen

### DIFF
--- a/sample-chat/src/main/java/com/quickblox/sample/chat/managers/DialogsManager.java
+++ b/sample-chat/src/main/java/com/quickblox/sample/chat/managers/DialogsManager.java
@@ -77,7 +77,7 @@ public class DialogsManager {
     }
 
     public void onGlobalMessageReceived(String dialogId, QBChatMessage chatMessage){
-        if (chatMessage.isMarkable()) { //for excluding status messages until will be released v.3.1
+        if (chatMessage.isMarkable()) {
             if (QbDialogHolder.getInstance().hasDialogWithId(dialogId)) {
                 QbDialogHolder.getInstance().updateDialog(dialogId, chatMessage);
                 notifyListenersDialogUpdated(dialogId);

--- a/sample-chat/src/main/java/com/quickblox/sample/chat/managers/DialogsManager.java
+++ b/sample-chat/src/main/java/com/quickblox/sample/chat/managers/DialogsManager.java
@@ -77,7 +77,7 @@ public class DialogsManager {
     }
 
     public void onGlobalMessageReceived(String dialogId, QBChatMessage chatMessage){
-        if (chatMessage.getBody() != null && chatMessage.isMarkable()) { //for excluding status messages until will be released v.3.1
+        if (chatMessage.isMarkable()) { //for excluding status messages until will be released v.3.1
             if (QbDialogHolder.getInstance().hasDialogWithId(dialogId)) {
                 QbDialogHolder.getInstance().updateDialog(dialogId, chatMessage);
                 notifyListenersDialogUpdated(dialogId);


### PR DESCRIPTION
*Make sure that you wrote the tests for your proposed changes and the existing test was success.*

**Made/Proposed changes:**
*(Don’t use general words, describe changes in details)*
- fixed method onGlobalMessageReceived to notify Dialog Listener when attachment received.

**How should this be manually tested?**
1. Log in as users who have common private and group chats
2. As User 1 stay on Chats screen
3. As User 2 send photo attachments to the group and private chats with User 1 -> Attachments are successfully sent
4. Verify User's 1 Chats screen

**Does the documentation need an update?**
Updating is not needed