### PR TITLE
Feature/andsamples-502

### DIFF
--- a/sample-chat/src/main/java/com/quickblox/sample/chat/managers/DialogsManager.java
+++ b/sample-chat/src/main/java/com/quickblox/sample/chat/managers/DialogsManager.java
@@ -104,11 +104,11 @@ public class DialogsManager {
             chatDialog.initForChat(QBChatService.getInstance());
 
             try {
-                chatDialog.join(new DiscussionHistory());
-            } catch (XMPPException xmppException) {
-                Toaster.shortToast(xmppException.getMessage());
-            } catch (SmackException smackException) {
-                Toaster.shortToast(smackException.getMessage());
+                DiscussionHistory history = new DiscussionHistory();
+                history.setMaxStanzas(0);
+                chatDialog.join(history);
+            } catch (Exception e) {
+                Toaster.shortToast(e.getMessage());
             }
             QbDialogHolder.getInstance().addDialog(chatDialog);
             notifyListenersDialogCreated(chatDialog);

--- a/sample-chat/src/main/java/com/quickblox/sample/chat/managers/DialogsManager.java
+++ b/sample-chat/src/main/java/com/quickblox/sample/chat/managers/DialogsManager.java
@@ -44,7 +44,6 @@ public class DialogsManager {
         qbChatMessage.setProperty(PROPERTY_DIALOG_NAME, String.valueOf(dialog.getName()));
         qbChatMessage.setProperty(PROPERTY_NOTIFICATION_TYPE, CREATING_DIALOG);
         qbChatMessage.setBody("New Chat Created");
-
         return qbChatMessage;
     }
 
@@ -55,7 +54,6 @@ public class DialogsManager {
         chatDialog.setType(QBDialogType.parseByCode(Integer.parseInt(qbChatMessage.getProperty(PROPERTY_DIALOG_TYPE).toString())));
         chatDialog.setName(qbChatMessage.getProperty(PROPERTY_DIALOG_NAME).toString());
         chatDialog.setUnreadMessageCount(0);
-
         return chatDialog;
     }
 

--- a/sample-chat/src/main/java/com/quickblox/sample/chat/managers/DialogsManager.java
+++ b/sample-chat/src/main/java/com/quickblox/sample/chat/managers/DialogsManager.java
@@ -7,13 +7,10 @@ import com.quickblox.chat.QBSystemMessagesManager;
 import com.quickblox.chat.model.QBChatDialog;
 import com.quickblox.chat.model.QBChatMessage;
 import com.quickblox.chat.model.QBDialogType;
-import com.quickblox.core.QBEntityCallback;
-import com.quickblox.core.exception.QBResponseException;
 import com.quickblox.sample.chat.utils.chat.ChatHelper;
 import com.quickblox.sample.chat.utils.qb.QbDialogHolder;
 import com.quickblox.sample.chat.utils.qb.QbDialogUtils;
 import com.quickblox.sample.chat.utils.qb.callback.QbEntityCallbackImpl;
-import com.quickblox.sample.core.utils.Toaster;
 import com.quickblox.users.model.QBUser;
 
 import org.jivesoftware.smack.SmackException;
@@ -107,7 +104,7 @@ public class DialogsManager {
             DiscussionHistory history = new DiscussionHistory();
             history.setMaxStanzas(0);
 
-            chatDialog.join(history, new QBEntityCallback() {
+            chatDialog.join(history, new QbEntityCallbackImpl() {
                 @Override
                 public void onSuccess(Object o, Bundle bundle) {
                     QbDialogHolder.getInstance().addDialog(chatDialog);
@@ -115,11 +112,6 @@ public class DialogsManager {
                     QbDialogHolder.getInstance().updateDialog(chatDialog.getDialogId(), systemMessage);
                     onGlobalMessageReceived(chatDialog.getDialogId(), systemMessage);
                     notifyListenersDialogUpdated(chatDialog.getDialogId());
-                }
-
-                @Override
-                public void onError(QBResponseException e) {
-                    Toaster.shortToast(e.getMessage());
                 }
             });
         }


### PR DESCRIPTION
*Make sure that you wrote the tests for your proposed changes and the existing test was success.*

**Made/Proposed changes:**
*(Don’t use general words, describe changes in details)*
- fixed work logic of Dialogs Screen, to handle all system messages
- fixed creating system message about Creating new dialog
- fiexd Android and iOS inconsistency with system messages in case creating dialogs 

**How should this be manually tested?**
- Log in as users who have common chats
- As User 1 stay on Chats screen
- Add Users to the same group
- Verify User's 1 Chats screen
Result: on Users 1  Dialogs Screen appears notification about creating a new Dialog.  
**Does the documentation need an update?**
Updates not needed